### PR TITLE
Cloud Quickstart breaks with redirects

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,2 +1,4 @@
+- <a href="https://github.com/groupby/issues/issues/954">iss2</a> Cloud Quickstart breaks with redirects
+
 Changelog
 ===

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,1 @@
 - <a href="https://github.com/groupby/issues/issues/954">iss2</a> Cloud Quickstart breaks with redirects
-
-Changelog
-===

--- a/flux/src/main/webapp/jsp/index.jsp
+++ b/flux/src/main/webapp/jsp/index.jsp
@@ -11,7 +11,7 @@
 <%@include file="includes/form.jsp"%>
 
   <c:if test="${!empty results.redirect}">
-    <c:redirect url="${results.redirect}"/> 
+    Found redirect: <c:out value="${results.redirect}"/>
   </c:if>
   
   


### PR DESCRIPTION
Created by: willwarren <img height="16px" src="https://avatars.githubusercontent.com/u/1261268?v=3">
Parent groupby/issues#954

currently the redirect is fired and a URL only available in the clients production system is tagged onto groupbycloud.com which leads to a 404.
