### PR TITLE
Quickstart match strategy, triggered rule / template / query rewrite and style changes

### DIFF
--- a/src/main/java/com/groupbyinc/quickstart/controller/MissingImageAttributeException.java
+++ b/src/main/java/com/groupbyinc/quickstart/controller/MissingImageAttributeException.java
@@ -1,0 +1,25 @@
+package com.groupbyinc.quickstart.controller;
+
+public class MissingImageAttributeException extends Exception {
+    String imageAttributeName = null;
+    
+    public MissingImageAttributeException() {
+        super();
+    }
+    
+    public MissingImageAttributeException(Exception e) {
+        super(e);
+    }
+    
+    public MissingImageAttributeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public String getImageAttributeName() {
+        return imageAttributeName;
+    }
+
+    public void setImageAttributeName(String imageAttributeName) {
+        this.imageAttributeName = imageAttributeName;
+    }
+}

--- a/src/main/java/com/groupbyinc/quickstart/controller/NavigationController.java
+++ b/src/main/java/com/groupbyinc/quickstart/controller/NavigationController.java
@@ -305,8 +305,10 @@ public class NavigationController {
 
             String strategy = DEFAULT_MATCH_STRATEGY;
             try {
-                strategy = matchStrategies[i].trim();
-                MatchStrategy oMatchStrategy = Utils.getMatchStrategy(strategy);
+                if (i < matchStrategies.length) {
+                    strategy = matchStrategies[i];
+                }
+                MatchStrategy oMatchStrategy = Utils.getMatchStrategy(strategy.trim());
                 if (oMatchStrategy != null) {
                     query.setMatchStrategy(oMatchStrategy);
                 }
@@ -320,8 +322,10 @@ public class NavigationController {
             
             String sortOrder = DEFAULT_SORT_ORDER;
             try {
-                sortOrder = sortOrders[i].trim();
-                Sort[] oSortOrder = Utils.getSortOrder(sortOrder);
+                if (i < sortOrders.length) {
+                    sortOrder = sortOrders[i];
+                }
+                Sort[] oSortOrder = Utils.getSortOrder(sortOrder.trim());
                 if (oSortOrder != null && oSortOrder.length > 0) {
                     //Remove the older sort order before we add in the new one
                     Utils.removeSortOrder(query.getSort());

--- a/src/main/java/com/groupbyinc/quickstart/controller/NavigationController.java
+++ b/src/main/java/com/groupbyinc/quickstart/controller/NavigationController.java
@@ -323,6 +323,10 @@ public class NavigationController {
                 sortOrder = sortOrders[i].trim();
                 Sort[] oSortOrder = Utils.getSortOrder(sortOrder);
                 if (oSortOrder != null && oSortOrder.length > 0) {
+                    //Remove the older sort order before we add in the new one
+                    Utils.removeSortOrder(query.getSort());
+                    
+                    //Now we can add in the new sort order
                     query.setSort(oSortOrder);
                 }
 

--- a/src/main/java/com/groupbyinc/quickstart/controller/NavigationController.java
+++ b/src/main/java/com/groupbyinc/quickstart/controller/NavigationController.java
@@ -218,6 +218,13 @@ public class NavigationController {
                 query.addExcludedNavigations(name.trim());
             }
         }
+        
+        String pageSize = getCookie(request, "pageSize",
+                "").trim();
+        if (StringUtils.isNotBlank(pageSize)) {
+            int iPageSize = Integer.parseInt(pageSize);
+            query.setPageSize(iPageSize);
+        }
 
         String bringToTop = getCookie(request, "bringToTop", "").trim();
         if (StringUtils.isNotBlank(bringToTop)) {
@@ -267,8 +274,8 @@ public class NavigationController {
         }
 
         // Define the page size.
-        query.setPageSize(ServletRequestUtils
-                .getIntParameter(request, "ps", 50));
+//        query.setPageSize(ServletRequestUtils
+//                .getIntParameter(request, "ps", 50));
 
         // Create a model that we will pass into the rendering JSP
         Map<String, Object> model = new HashMap<String, Object>();

--- a/src/main/java/com/groupbyinc/quickstart/controller/NavigationController.java
+++ b/src/main/java/com/groupbyinc/quickstart/controller/NavigationController.java
@@ -15,6 +15,7 @@ import com.groupbyinc.common.jackson.Mappers;
 import com.groupbyinc.quickstart.helper.Utils;
 import com.groupbyinc.quickstart.model.QuickstartResults;
 import com.groupbyinc.util.UrlBeautifier;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,6 +26,7 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.jsp.JspException;
+
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,17 +41,19 @@ import java.util.Map;
 import static java.util.Collections.singletonList;
 
 /**
- * NavigationController is the single entry point for search and navigation
- * in the quickstart application.
+ * NavigationController is the single entry point for search and navigation in
+ * the quickstart application.
  */
 @Controller
 public class NavigationController {
+    private static final String DEFAULT_MATCH_STRATEGY = "[{ 'terms': 2, 'mustMatch': 2 }, { 'terms': 3, 'mustMatch': 2 }, { 'terms': 4, 'mustMatch': 3 }, { 'terms': 5, 'mustMatch': 3 }, { 'terms': 6, 'mustMatch': 4 }, { 'terms': 7, 'mustMatch': 4 }, { 'terms': 8, 'mustMatch': 5 }, { 'termsGreaterThan': 8, 'mustMatch': 60, 'percentage': true }]";
     private HashMap<String, Query> queryQueue = new HashMap<String, Query>();
     private HashMap<String, CloudBridge> bridgeQueue = new HashMap<String, CloudBridge>();
 
     @RequestMapping(value = "/moreRefinements.html")
-    ModelAndView getMoreNavigations(@RequestParam String navigationName, @RequestParam String selectedRefinements,
-                                    HttpServletRequest request) throws IOException, JspException {
+    ModelAndView getMoreNavigations(@RequestParam String navigationName,
+            @RequestParam String selectedRefinements, HttpServletRequest request)
+            throws IOException, JspException {
         String clientKey = getCookie(request, "clientKey", "").trim();
 
         Query query = queryQueue.get(clientKey);
@@ -58,7 +62,8 @@ public class NavigationController {
         navigationName = navigationName.trim();
 
         Map<String, Object> model = new HashMap<String, Object>();
-        Navigation availableNavigation = new Navigation().setName(navigationName);
+        Navigation availableNavigation = new Navigation()
+                .setName(navigationName);
 
         if (query == null || bridge == null) {
             model.put("results", null);
@@ -67,17 +72,22 @@ public class NavigationController {
         }
 
         Results results = new Results();
-        results.setSelectedNavigation(Utils.getSelectedNavigations(selectedRefinements));
+        results.setSelectedNavigation(Utils
+                .getSelectedNavigations(selectedRefinements));
         RefinementsResult refinementsResults = bridge.refinements(
-                new Query().setArea(query.getArea()).addRefinementsByString(query.getRefinementString())
-                           .setCollection(query.getCollection()), navigationName);
+                new Query().setArea(query.getArea())
+                        .addRefinementsByString(query.getRefinementString())
+                        .setCollection(query.getCollection()), navigationName);
 
-        if (refinementsResults != null && refinementsResults.getNavigation() != null) {
-            List<Refinement> refinementList = refinementsResults.getNavigation().getRefinements();
+        if (refinementsResults != null
+                && refinementsResults.getNavigation() != null) {
+            List<Refinement> refinementList = refinementsResults
+                    .getNavigation().getRefinements();
             if (refinementsResults.getNavigation().isOr()) {
                 availableNavigation.setOr(true);
             }
-            availableNavigation.setDisplayName(refinementsResults.getNavigation().getDisplayName());
+            availableNavigation.setDisplayName(refinementsResults
+                    .getNavigation().getDisplayName());
             availableNavigation.setRefinements(refinementList);
         }
         results.setQuery(query.getQuery());
@@ -87,19 +97,26 @@ public class NavigationController {
         return new ModelAndView("/includes/navLink.jsp", model);
     }
 
-    @RequestMapping({"**/index.html"})
-    protected ModelAndView handleSearch(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    @RequestMapping({ "**/index.html" })
+    protected ModelAndView handleSearch(HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
         // Get the action from the request.
-        String action = ServletRequestUtils.getStringParameter(request, "action", null);
+        String action = ServletRequestUtils.getStringParameter(request,
+                "action", null);
 
-        // The UrlBeautifier deconstructs a URL into a query object.  You can create as many url
-        // beautifiers as you want which may correspond to different kinds of urls that you want
-        // to generate.  Here we construct one called 'default' that we use for every search and
+        // The UrlBeautifier deconstructs a URL into a query object. You can
+        // create as many url
+        // beautifiers as you want which may correspond to different kinds of
+        // urls that you want
+        // to generate. Here we construct one called 'default' that we use for
+        // every search and
         // navigation URL.
-        UrlBeautifier defaultUrlBeautifier = UrlBeautifier.getUrlBeautifiers().get("default");
+        UrlBeautifier defaultUrlBeautifier = UrlBeautifier.getUrlBeautifiers()
+                .get("default");
         if (defaultUrlBeautifier == null) {
             UrlBeautifier.createUrlBeautifier("default");
-            defaultUrlBeautifier = UrlBeautifier.getUrlBeautifiers().get("default");
+            defaultUrlBeautifier = UrlBeautifier.getUrlBeautifiers().get(
+                    "default");
             defaultUrlBeautifier.addRefinementMapping('s', "size");
             defaultUrlBeautifier.setSearchMapping('q');
             defaultUrlBeautifier.setAppend("/index.html");
@@ -108,10 +125,12 @@ public class NavigationController {
         }
 
         // Create the query object from the beautifier
-        Query query = defaultUrlBeautifier.fromUrl(request.getRequestURI(), new Query());
+        Query query = defaultUrlBeautifier.fromUrl(request.getRequestURI(),
+                new Query());
 
         // return all fields with each record.
-        // If there are specific fields defined, use these, otherwise default to showing all fields.
+        // If there are specific fields defined, use these, otherwise default to
+        // showing all fields.
         boolean debug = false;
         String fieldString = getCookie(request, "fields", "").trim();
         if (StringUtils.isNotBlank(fieldString)) {
@@ -120,7 +139,8 @@ public class NavigationController {
                 if (StringUtils.isNotBlank(field)) {
                     query.addFields(field.trim());
                 }
-                // this debug endpoint for search is temporary and maybe removed without warning.
+                // this debug endpoint for search is temporary and maybe removed
+                // without warning.
                 if (field.trim().equalsIgnoreCase("debug")) {
                     debug = true;
                     if (fields.length == 1) {
@@ -153,7 +173,8 @@ public class NavigationController {
             query.setLanguage(language);
         }
 
-        // If you have data in different collections you can specify the specific
+        // If you have data in different collections you can specify the
+        // specific
         // collection you wish to query against.
         String collection = getCookie(request, "collection", "").trim();
         if (StringUtils.isNotBlank(collection)) {
@@ -180,14 +201,16 @@ public class NavigationController {
             }
         }
 
-        String includedNavigations = getCookie(request, "includedNavigations", "").trim();
+        String includedNavigations = getCookie(request, "includedNavigations",
+                "").trim();
         if (StringUtils.isNotBlank(includedNavigations)) {
             for (String name : StringUtils.split(includedNavigations, ",")) {
                 query.addIncludedNavigations(name.trim());
             }
         }
 
-        String excludedNavigations = getCookie(request, "excludedNavigations", "").trim();
+        String excludedNavigations = getCookie(request, "excludedNavigations",
+                "").trim();
         if (StringUtils.isNotBlank(excludedNavigations)) {
             for (String name : StringUtils.split(excludedNavigations, ",")) {
                 query.addExcludedNavigations(name.trim());
@@ -201,15 +224,19 @@ public class NavigationController {
             }
         }
 
-        // If there are additional refinements that aren't being beautified get these from the
+        // If there are additional refinements that aren't being beautified get
+        // these from the
         // URL and add them to the query.
-        String refinements = ServletRequestUtils.getStringParameter(request, "refinements", "");
+        String refinements = ServletRequestUtils.getStringParameter(request,
+                "refinements", "");
         if (StringUtils.isNotBlank(refinements)) {
             query.addRefinementsByString(refinements);
         }
 
-        // If the search string has not been beautified get it from the URL parameters.
-        String queryString = ServletRequestUtils.getStringParameter(request, "q", "");
+        // If the search string has not been beautified get it from the URL
+        // parameters.
+        String queryString = ServletRequestUtils.getStringParameter(request,
+                "q", "");
         if (StringUtils.isNotBlank(queryString)) {
             query.setQuery(queryString);
         }
@@ -217,44 +244,50 @@ public class NavigationController {
         // If we're paging through results set the skip from the url params
         query.setSkip(ServletRequestUtils.getIntParameter(request, "p", 0));
 
-        // If the query is supposed to be beautified, and it was in fact in the URL params
-        // send a redirect command to the browser to redirect to the beautified URL.
+        // If the query is supposed to be beautified, and it was in fact in the
+        // URL params
+        // send a redirect command to the browser to redirect to the beautified
+        // URL.
         String incoming = request.getRequestURI();
-        String beautified = request.getContextPath() + defaultUrlBeautifier.toUrl(
-                query.getQuery(), query.getNavigations());
+        String beautified = request.getContextPath()
+                + defaultUrlBeautifier.toUrl(query.getQuery(),
+                        query.getNavigations());
         if (!beautified.startsWith(incoming)) {
             response.sendRedirect(beautified);
             return null;
         }
 
         // Define the page size.
-        query.setPageSize(ServletRequestUtils.getIntParameter(request, "ps", 50));
+        query.setPageSize(ServletRequestUtils
+                .getIntParameter(request, "ps", 50));
 
         // Create a model that we will pass into the rendering JSP
         Map<String, Object> model = new HashMap<String, Object>();
-        ModelAndView modelAndView = new ModelAndView("getOrderList".equals(action) ? "orderList.jsp" : "index.jsp");
+        ModelAndView modelAndView = new ModelAndView(
+                "getOrderList".equals(action) ? "orderList.jsp" : "index.jsp");
         modelAndView.addObject("model", model);
 
         // put back the customerId
         model.put("customerId", customerId);
 
-        // If a specific biasing profile is set in the url params set it on the query.
+        // If a specific biasing profile is set in the url params set it on the
+        // query.
         String biasingProfile = getCookie(request, "biasingProfile", "").trim();
 
         // We will run this query multiple times for each biasing profile found
         String[] biasingProfiles = biasingProfile.split(",", -1);
         if (biasingProfiles.length == 0) {
-            biasingProfiles = new String[]{""};
+            biasingProfiles = new String[] { "" };
         }
         model.put("biasingProfileCount", biasingProfiles.length);
 
-		String matchStrategy = getCookie(request, "matchStrategy", "").trim();
+        String matchStrategy = getCookie(request, "matchStrategy", "").trim();
 
-		String[] matchStrategies = matchStrategy.split("\\|", -1);
-		if (matchStrategies.length == 0) {
-			matchStrategies = new String[] { "" };
-		}
-		model.put("matchStrategyCount", matchStrategies.length);
+        String[] matchStrategies = matchStrategy.split("\\|", -1);
+        if (matchStrategies.length == 0) {
+            matchStrategies = new String[] { "" };
+        }
+        model.put("matchStrategyCount", matchStrategies.length);
 
         for (int i = 0; i < biasingProfiles.length; i++) {
             String profile = biasingProfiles[i].trim();
@@ -263,23 +296,25 @@ public class NavigationController {
                 query.setBiasingProfile(profile);
             }
 
-			String strategy = "[{ 'terms': 2, 'mustMatch': 2 }, { 'terms': 3, 'mustMatch': 2 }, { 'terms': 4, 'mustMatch': 3 }, { 'terms': 5, 'mustMatch': 3 }, { 'terms': 6, 'mustMatch': 4 }, { 'terms': 7, 'mustMatch': 4 }, { 'terms': 8, 'mustMatch': 5 }, { 'termsGreaterThan': 8, 'mustMatch': 60, 'percentage': true }]";
-			try {
-				strategy = matchStrategies[i].trim();
-				MatchStrategy oMatchStrategy = Utils.getMatchStrategy(strategy);
-				if (oMatchStrategy != null) {
-					query.setMatchStrategy(oMatchStrategy);
-				}
+            String strategy = DEFAULT_MATCH_STRATEGY;
+            try {
+                strategy = matchStrategies[i].trim();
+                MatchStrategy oMatchStrategy = Utils.getMatchStrategy(strategy);
+                if (oMatchStrategy != null) {
+                    query.setMatchStrategy(oMatchStrategy);
+                }
 
-			} catch (Exception e) {
-				// swallow any exception in attempting to get / set a match
-				// strategy
-			}
+            } catch (Exception e) {
+                // Output error and swallow exception
+                // Note that any error at this point means that the default
+                // match strategy will be applied
+                e.printStackTrace();
+            }
 
-			// pass the raw json representation of the query into the view
-			// regardless of errors
-			model.put("rawQuery" + i, query.setReturnBinary(false)
-					.getBridgeJson(clientKey));
+            // pass the raw json representation of the query into the view
+            // regardless of errors
+            model.put("rawQuery" + i, query.setReturnBinary(false)
+                    .getBridgeJson(clientKey));
             model.put("originalQuery" + i, query);
             query.setReturnBinary(true);
             try {
@@ -288,17 +323,18 @@ public class NavigationController {
                 if (StringUtils.isNotBlank(clientKey)) {
                     long startTime = System.currentTimeMillis();
                     results = bridge.search(query);
-                    model.put("time" + i, System.currentTimeMillis() - startTime);
+                    model.put("time" + i, System.currentTimeMillis()
+                            - startTime);
                 }
                 // pass the results into the view.
-				QuickstartResults quickstartResults = new QuickstartResults(
-						results);
-
-				quickstartResults.setMatchStrategy(strategy);
-				model.put("results" + i, quickstartResults);
+                QuickstartResults quickstartResults = new QuickstartResults(
+                        results);
+                quickstartResults.setMatchStrategy(strategy);
+                model.put("results" + i, quickstartResults);
                 model.put(
-                        "resultsJson" + i, debug ? doDebugQueryThroughUrl(clientKey, customerId, query)
-                                                 : Mappers.writeValueAsString(results));
+                        "resultsJson" + i,
+                        debug ? doDebugQueryThroughUrl(clientKey, customerId,
+                                query) : Mappers.writeValueAsString(results));
             } catch (Exception e) {
                 // Something went wrong.
                 e.printStackTrace();
@@ -318,23 +354,27 @@ public class NavigationController {
     }
 
     /**
-     * Temporary method for debugging queries.  The debug parameter maybe discontinued without warning.
-     *
+     * Temporary method for debugging queries. The debug parameter maybe
+     * discontinued without warning.
+     * 
      * @param clientKey
      * @param customerId
      * @param query
-     *
+     * 
      * @return
      */
-    private String doDebugQueryThroughUrl(String clientKey, String customerId, Query query) {
+    private String doDebugQueryThroughUrl(String clientKey, String customerId,
+            Query query) {
         DataOutputStream outputStream = null;
         InputStream inputStream = null;
         try {
             query.setReturnBinary(false);
             byte[] postData = query.getBridgeJson(clientKey).getBytes("UTF-8");
 
-            // this debug endpoint for search is temporary and maybe removed without warning.
-            URL url = new URL("https://" + customerId + ".groupbycloud.com/api/v1/search?debug");
+            // this debug endpoint for search is temporary and maybe removed
+            // without warning.
+            URL url = new URL("https://" + customerId
+                    + ".groupbycloud.com/api/v1/search?debug");
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setDoOutput(true);
             conn.setDoInput(true);
@@ -342,7 +382,8 @@ public class NavigationController {
             conn.setRequestMethod("POST");
             conn.setRequestProperty("Content-Type", "application/json");
             conn.setRequestProperty("charset", "utf-8");
-            conn.setRequestProperty("Content-Length", Integer.toString(postData.length));
+            conn.setRequestProperty("Content-Length",
+                    Integer.toString(postData.length));
             conn.setUseCaches(false);
             outputStream = new DataOutputStream(conn.getOutputStream());
             outputStream.write(postData);
@@ -359,16 +400,18 @@ public class NavigationController {
     }
 
     /**
-     * Helper method to get cookie values.  We use this for storing the clientKey and customerId, though
-     * these values should typically be put in a properties file.
-     *
+     * Helper method to get cookie values. We use this for storing the clientKey
+     * and customerId, though these values should typically be put in a
+     * properties file.
+     * 
      * @param pRequest
      * @param pName
      * @param pDefault
-     *
+     * 
      * @return the value of the named cookie, or default if it was not found.
      */
-    private String getCookie(HttpServletRequest pRequest, String pName, String pDefault) {
+    private String getCookie(HttpServletRequest pRequest, String pName,
+            String pDefault) {
         Cookie[] cookies = pRequest.getCookies();
         if (pRequest.getCookies() != null) {
             for (Cookie cookie : cookies) {

--- a/src/main/java/com/groupbyinc/quickstart/helper/Utils.java
+++ b/src/main/java/com/groupbyinc/quickstart/helper/Utils.java
@@ -115,4 +115,12 @@ public class Utils {
         }
         return sortArray;
     }
+    
+    public static void removeSortOrder(List<Sort> sortList) {
+        if (sortList.isEmpty()) return;
+        
+        for (int i = sortList.size()-1; i >= 0; i--) {
+            sortList.remove(i);
+        }
+    }
 }

--- a/src/main/java/com/groupbyinc/quickstart/helper/Utils.java
+++ b/src/main/java/com/groupbyinc/quickstart/helper/Utils.java
@@ -21,55 +21,56 @@ import java.util.List;
  */
 public class Utils {
 
-    public static List<Navigation> getSelectedNavigations(String refinements){
+    public static List<Navigation> getSelectedNavigations(String refinements) {
         List<Navigation> selectedNavigations = new ArrayList<Navigation>();
-        if(!refinements.isEmpty()){
+        if (!refinements.isEmpty()) {
             String[] refs = refinements.split(",");
-            for(String s : refs){
+            for (String s : refs) {
                 String[] navsAndRefs = s.split("=");
-                int index = selectedNavigations.indexOf(new Navigation().setName(navsAndRefs[0]));
-                if(index != -1){
-                    selectedNavigations.get(index).getRefinements().add(new RefinementValue().setValue(navsAndRefs[1]));
-                } else{
+                int index = selectedNavigations.indexOf(new Navigation()
+                        .setName(navsAndRefs[0]));
+                if (index != -1) {
+                    selectedNavigations
+                            .get(index)
+                            .getRefinements()
+                            .add(new RefinementValue().setValue(navsAndRefs[1]));
+                } else {
                     List<Refinement> refVals = new ArrayList<Refinement>();
                     refVals.add(new RefinementValue().setValue(navsAndRefs[1]));
-                    selectedNavigations.add(new Navigation().setName(navsAndRefs[0]).setRefinements(refVals));
+                    selectedNavigations.add(new Navigation().setName(
+                            navsAndRefs[0]).setRefinements(refVals));
                 }
             }
         }
         return selectedNavigations;
     }
-    
-	public static MatchStrategy getMatchStrategy(String jsonString) {
-		jsonString = jsonString.replace("'", "\"");
-		
-		if (!(jsonString.startsWith("[") && jsonString.endsWith("]"))) {
-			jsonString = "[" + jsonString + "]";
-		} else if (!jsonString.startsWith("[") || !jsonString.endsWith("]")) {
-			return null;
-		}
-		ObjectMapper mapper = new ObjectMapper();
-		List<PartialMatchRule> rules = null;
-		try {
-			rules = mapper.readValue(jsonString, new TypeReference<List<PartialMatchRule>>(){});
-		} catch (JsonParseException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		} catch (JsonMappingException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		
-		MatchStrategy matchStrategy = null;
-		
-		if (rules != null) {
-			matchStrategy = new MatchStrategy();
-			matchStrategy.setRules(rules);
-		}
-		
-		return matchStrategy;
-	}
+
+    public static MatchStrategy getMatchStrategy(String jsonString) {
+        jsonString = jsonString.replace("'", "\"");
+
+        if (!(jsonString.startsWith("[") && jsonString.endsWith("]"))) {
+            jsonString = "[" + jsonString + "]";
+        } else if (!jsonString.startsWith("[") || !jsonString.endsWith("]")) {
+            return null;
+        }
+        ObjectMapper mapper = new ObjectMapper();
+        List<PartialMatchRule> rules = null;
+        try {
+            rules = mapper.readValue(jsonString,
+                    new TypeReference<List<PartialMatchRule>>() {
+                    });
+        } catch (Exception e) {
+            // Output error and swallow exception
+            e.printStackTrace();
+        }
+
+        MatchStrategy matchStrategy = null;
+
+        if (rules != null) {
+            matchStrategy = new MatchStrategy();
+            matchStrategy.setRules(rules);
+        }
+
+        return matchStrategy;
+    }
 }

--- a/src/main/java/com/groupbyinc/quickstart/helper/Utils.java
+++ b/src/main/java/com/groupbyinc/quickstart/helper/Utils.java
@@ -1,9 +1,18 @@
 package com.groupbyinc.quickstart.helper;
 
+import com.groupbyinc.api.model.MatchStrategy;
 import com.groupbyinc.api.model.Navigation;
+import com.groupbyinc.api.model.PartialMatchRule;
 import com.groupbyinc.api.model.Refinement;
+import com.groupbyinc.api.model.Results;
 import com.groupbyinc.api.model.refinement.RefinementValue;
+import com.groupbyinc.common.jackson.core.JsonParseException;
+import com.groupbyinc.common.jackson.core.type.TypeReference;
+import com.groupbyinc.common.jackson.databind.JsonMappingException;
+import com.groupbyinc.common.jackson.databind.ObjectMapper;
+import com.groupbyinc.quickstart.model.QuickstartResults;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,4 +39,37 @@ public class Utils {
         }
         return selectedNavigations;
     }
+    
+	public static MatchStrategy getMatchStrategy(String jsonString) {
+		jsonString = jsonString.replace("'", "\"");
+		
+		if (!(jsonString.startsWith("[") && jsonString.endsWith("]"))) {
+			jsonString = "[" + jsonString + "]";
+		} else if (!jsonString.startsWith("[") || !jsonString.endsWith("]")) {
+			return null;
+		}
+		ObjectMapper mapper = new ObjectMapper();
+		List<PartialMatchRule> rules = null;
+		try {
+			rules = mapper.readValue(jsonString, new TypeReference<List<PartialMatchRule>>(){});
+		} catch (JsonParseException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} catch (JsonMappingException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		
+		MatchStrategy matchStrategy = null;
+		
+		if (rules != null) {
+			matchStrategy = new MatchStrategy();
+			matchStrategy.setRules(rules);
+		}
+		
+		return matchStrategy;
+	}
 }

--- a/src/main/java/com/groupbyinc/quickstart/helper/Utils.java
+++ b/src/main/java/com/groupbyinc/quickstart/helper/Utils.java
@@ -5,6 +5,7 @@ import com.groupbyinc.api.model.Navigation;
 import com.groupbyinc.api.model.PartialMatchRule;
 import com.groupbyinc.api.model.Refinement;
 import com.groupbyinc.api.model.Results;
+import com.groupbyinc.api.model.Sort;
 import com.groupbyinc.api.model.refinement.RefinementValue;
 import com.groupbyinc.common.jackson.core.JsonParseException;
 import com.groupbyinc.common.jackson.core.type.TypeReference;
@@ -72,5 +73,46 @@ public class Utils {
         }
 
         return matchStrategy;
+    }
+    
+    public static String getCustomerId(StringBuffer requestUrl) {
+        String customerID = null;
+        
+        try {
+            String temp = requestUrl.substring(requestUrl.indexOf("://")+3);
+            customerID = temp.substring(0,temp.indexOf("."));
+        } catch (Exception e) {
+            //Failed to parse out the customer ID from the URL
+            e.printStackTrace();
+        }
+        
+        return customerID;
+    }
+
+    public static Sort[] getSortOrder(String jsonString) {
+        jsonString = jsonString.replace("'", "\"");
+
+        if (!(jsonString.startsWith("[") && jsonString.endsWith("]"))) {
+            jsonString = "[" + jsonString + "]";
+        } else if (!jsonString.startsWith("[") || !jsonString.endsWith("]")) {
+            return null;
+        }
+        ObjectMapper mapper = new ObjectMapper();
+        List<Sort> sorts = null;
+        try {
+            sorts = mapper.readValue(jsonString,
+                    new TypeReference<List<Sort>>() {
+                    });
+        } catch (Exception e) {
+            // Output error and swallow exception
+            e.printStackTrace();
+        }
+
+        Sort[] sortArray = null;
+        if (sorts != null && !sorts.isEmpty()) {
+            sortArray = new Sort[sorts.size()];
+            sortArray = sorts.toArray(sortArray);
+        }
+        return sortArray;
     }
 }

--- a/src/main/java/com/groupbyinc/quickstart/model/QuickstartResults.java
+++ b/src/main/java/com/groupbyinc/quickstart/model/QuickstartResults.java
@@ -1,0 +1,36 @@
+package com.groupbyinc.quickstart.model;
+
+import com.groupbyinc.api.model.Results;
+
+public class QuickstartResults extends Results {
+	private String matchStrategy = null;
+	
+	public QuickstartResults(Results results) {
+		super();
+		this.setArea(results.getArea());
+		this.setAvailableNavigation(results.getAvailableNavigation());
+		this.setBiasingProfile(results.getBiasingProfile());
+		this.setCorrectedQuery(results.getCorrectedQuery());
+		this.setDidYouMean(results.getDidYouMean());
+		this.setErrors(results.getErrors());
+		this.setOriginalQuery(results.getOriginalQuery());
+		this.setPageInfo(results.getPageInfo());
+		this.setQuery(results.getQuery());
+		this.setRecords(results.getRecords());
+		this.setRedirect(results.getRedirect());
+		this.setRelatedQueries(results.getRelatedQueries());
+		this.setRewrites(results.getRewrites());
+		this.setSelectedNavigation(results.getSelectedNavigation());
+		this.setSiteParams(results.getSiteParams());
+		this.setTemplate(results.getTemplate());
+		this.setTotalRecordCount(results.getTotalRecordCount());
+	}
+
+	public String getMatchStrategy() {
+		return matchStrategy;
+	}
+
+	public void setMatchStrategy(String matchStrategy) {
+		this.matchStrategy = matchStrategy;
+	}
+}

--- a/src/main/java/com/groupbyinc/quickstart/model/QuickstartResults.java
+++ b/src/main/java/com/groupbyinc/quickstart/model/QuickstartResults.java
@@ -4,6 +4,7 @@ import com.groupbyinc.api.model.Results;
 
 public class QuickstartResults extends Results {
     private String matchStrategy = null;
+    private String sortOrder = null;
 
     public QuickstartResults(Results results) {
         super();
@@ -32,5 +33,13 @@ public class QuickstartResults extends Results {
 
     public void setMatchStrategy(String matchStrategy) {
         this.matchStrategy = matchStrategy;
+    }
+
+    public String getSortOrder() {
+        return sortOrder;
+    }
+
+    public void setSortOrder(String sortOrder) {
+        this.sortOrder = sortOrder;
     }
 }

--- a/src/main/java/com/groupbyinc/quickstart/model/QuickstartResults.java
+++ b/src/main/java/com/groupbyinc/quickstart/model/QuickstartResults.java
@@ -3,34 +3,34 @@ package com.groupbyinc.quickstart.model;
 import com.groupbyinc.api.model.Results;
 
 public class QuickstartResults extends Results {
-	private String matchStrategy = null;
-	
-	public QuickstartResults(Results results) {
-		super();
-		this.setArea(results.getArea());
-		this.setAvailableNavigation(results.getAvailableNavigation());
-		this.setBiasingProfile(results.getBiasingProfile());
-		this.setCorrectedQuery(results.getCorrectedQuery());
-		this.setDidYouMean(results.getDidYouMean());
-		this.setErrors(results.getErrors());
-		this.setOriginalQuery(results.getOriginalQuery());
-		this.setPageInfo(results.getPageInfo());
-		this.setQuery(results.getQuery());
-		this.setRecords(results.getRecords());
-		this.setRedirect(results.getRedirect());
-		this.setRelatedQueries(results.getRelatedQueries());
-		this.setRewrites(results.getRewrites());
-		this.setSelectedNavigation(results.getSelectedNavigation());
-		this.setSiteParams(results.getSiteParams());
-		this.setTemplate(results.getTemplate());
-		this.setTotalRecordCount(results.getTotalRecordCount());
-	}
+    private String matchStrategy = null;
 
-	public String getMatchStrategy() {
-		return matchStrategy;
-	}
+    public QuickstartResults(Results results) {
+        super();
+        this.setArea(results.getArea());
+        this.setAvailableNavigation(results.getAvailableNavigation());
+        this.setBiasingProfile(results.getBiasingProfile());
+        this.setCorrectedQuery(results.getCorrectedQuery());
+        this.setDidYouMean(results.getDidYouMean());
+        this.setErrors(results.getErrors());
+        this.setOriginalQuery(results.getOriginalQuery());
+        this.setPageInfo(results.getPageInfo());
+        this.setQuery(results.getQuery());
+        this.setRecords(results.getRecords());
+        this.setRedirect(results.getRedirect());
+        this.setRelatedQueries(results.getRelatedQueries());
+        this.setRewrites(results.getRewrites());
+        this.setSelectedNavigation(results.getSelectedNavigation());
+        this.setSiteParams(results.getSiteParams());
+        this.setTemplate(results.getTemplate());
+        this.setTotalRecordCount(results.getTotalRecordCount());
+    }
 
-	public void setMatchStrategy(String matchStrategy) {
-		this.matchStrategy = matchStrategy;
-	}
+    public String getMatchStrategy() {
+        return matchStrategy;
+    }
+
+    public void setMatchStrategy(String matchStrategy) {
+        this.matchStrategy = matchStrategy;
+    }
 }

--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -326,3 +326,14 @@ display: inline-block;
     left: 10px;
 }
 
+.resultSortOrder {
+	position:relative;
+}
+
+.rightSortOrder {
+	position:absolute;
+	right:0;
+	top:0;
+	font-size:12px;
+}
+

--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -292,13 +292,20 @@ label {
 }
 
 .toggleMatchStrategy {
-	font-size:12px;
+	font-size:14px;
 }
 
 .resultMatchStrategy {
 	position:relative;
 	background-color:#EEEEEE;
 	display:none;
+}
+
+.resultMatchStrategy textarea {
+	display:block;
+	margin-left: auto;
+	margin-right: auto;
+	width:95%;
 }
 
 .leftMatchStrategy {
@@ -333,13 +340,20 @@ display: inline-block;
 }
 
 .toggleSortOrder {
-	font-size:12px;
+	font-size:14px;
 }
 
 .resultSortOrder {
 	position:relative;
 	background-color:#EEEEEE;
 	display:none;
+}
+
+.resultSortOrder textarea {
+	display:block;
+	margin-left: auto;
+	margin-right: auto;
+	width:95%;
 }
 
 .leftSortOrder {

--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -342,6 +342,13 @@ display: inline-block;
 	display:none;
 }
 
+.leftSortOrder {
+	position:absolute;
+	left:0;
+	top:0;
+	font-size:12px;
+}
+
 .rightSortOrder {
 	position:absolute;
 	right:0;

--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -3,16 +3,40 @@ html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockq
     padding: 0;
     border: 0;
     font: inherit;
-    font-family: Arial;
+    font-family: Verdana, "Helvetica Neue",Arial, sans-serif;
 }
 
 body {
     margin: 2px;
 }
 
+a {
+color: #0084BF;
+}
+
 /* HTML5 display-role reset for older browsers */
 article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section {
     display: block;
+}
+
+input[type="text"], textarea,select {
+border: 1px solid #DADADA;
+    color: #888;
+    /* height: 30px; */
+    margin-bottom: 1px;
+    /* margin-right: 6px; */
+    /* margin-top: 2px; */
+    outline: 0 none;
+    padding: 3px 3px 3px 5px;
+    /* width: 70%; */
+    /* font-size: 12px; */
+    /* line-height: 15px; */
+    box-shadow: inset 0px 1px 4px #ECECEC;
+    -moz-box-shadow: inset 0px 1px 4px #ECECEC;
+    -webkit-box-shadow: inset 0px 1px 4px #ECECEC;
+      -webkit-border-radius: 5px;
+        -moz-border-radius: 5px;
+    border-radius: 5px;
 }
 
 .transparent {
@@ -44,11 +68,16 @@ table {
     border-collapse: collapse;
     border-spacing: 0;
 }
+.keyValue {
+    padding-bottom: 3px;
+}
 
 .record {
-    width: 350px;
-    border: 1px solid white;
+    width: 400px;
+    border: 1px solid #CCCCCC;
     font-size: 13px;
+    /* padding: 2px; */
+    margin: 5px;
 }
 
 .record .details b {
@@ -57,14 +86,28 @@ table {
 
 .record .details {
     margin-left: 20px;
-}
+} 
 
 h2 {
-    background-color: #008800;
+    background-color: #315231;
     padding: 4px;
     color: white;
     font-size: 18px;
     margin-bottom: 10px;
+}
+
+h3 {
+    background-color: #EEEEEE;
+    padding: 4px;
+    color: black;
+    font-size: 16px;
+    
+    margin-bottom: 10px;
+font-weight: bolder;
+}
+
+h3 strong {
+font-weight: normal;
 }
 
 select {
@@ -77,21 +120,37 @@ select {
     margin-bottom: 10px;
 }
 
-.navigation {
-    background-color: #007700;
-    padding: 4px;
-    color: white;
+#nav-categoryl1 > div:nth-child(even) {
+color:red;
 }
 
-.page {
-    float: right
+.navigation {
+    border: 1px solid #cccccc;
+    border-radius: 5px;
+    background: #315231;
+    background: -moz-linear-gradient(left, #bfbfbf, #ffffff);
+    background: -webkit-linear-gradient(left, #bfbfbf, #ffffff);
+    background: -o-linear-gradient(left, #bfbfbf, #ffffff);
+    background: -ms-linear-gradient(left, #bfbfbf, #ffffff);
+    background: linear-gradient(to left, #bfbfbf, #FFFFFF);
+    color: black;
+}
+
+
+.page a {
+    color: #907D7D;
+    float: right;
 }
 
 form {
     padding: 4px;
     color: white;
-    background-color: #007700;
+    background-color: #315231;
     margin-bottom: 10px;
+    box-shadow: inset 0px 1px 4px #ECECEC;
+    -moz-box-shadow: inset 0px 1px 4px #ECECEC;
+    -webkit-box-shadow: inset 0px 1px 4px #ECECEC;
+    
 }
 
 #refinementsDiv {
@@ -151,17 +210,23 @@ label {
 }
 
 .navLink {
-    max-height: 200px;
-    overflow: auto;
-    padding-top: 10px;
-    padding-bottom: 10px;
-    border-top: 10px solid #007700;
-    line-height: 12px;
-    font-size: 11px;
+     max-height: 250px;
+     overflow: auto;
+     border-top: 1px solid #005500;
+     line-height: 12px;
+     font-size: 11px;
+     display: block;
+     padding: 14px 12px;
+     /* font-family: Helvetica, Arial, sans-serif; */
+     font-size: 16px;
+     font-weight: bold;
+     text-decoration: none;
+    color: black;
 }
 
 .navLink b {
     font-weight: bolder;
+    font-size: 12px;
 }
 
 .navLink a:hover {
@@ -173,7 +238,8 @@ label {
     font-size: 11px;
     margin-left: 4px;
     text-decoration: none;
-    color: white;
+    font-weight: normal;
+    color: black;
 }
 
 #raw pre {
@@ -201,7 +267,7 @@ label {
 }
 
 .largeResponse {
-    background-color: red;
+    background-color: #EFB0B0;
     padding-left: 4px;
     padding-right: 4px;
 }
@@ -221,6 +287,42 @@ label {
 }
 
 .highlight {
-    background-color: yellow;
-    border: 1px solid yellow;
+	background: rgba(251, 255, 0, 0.25);
+
 }
+
+.resultMatchStrategy {
+	position:relative;
+}
+
+.leftMatchStrategy {
+	position:absolute;
+	left:0;
+	top:0;
+	font-size:12px;
+}
+
+.rightMatchStrategy {
+	position:absolute;
+	right:0;
+	top:0;
+	font-size:12px;
+}
+
+.resultBiasAndCount {
+	position:relative;
+}
+
+.totalRecordCountTitle, .totalRecordCount {
+display: inline-block;
+    top: 0;
+    font-size: 12px;
+    font-weight: bold;
+}
+.totalRecordCountTitle {
+
+    font-weight: normal;
+    display: inline-block;
+    left: 10px;
+}
+

--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -291,8 +291,14 @@ label {
 
 }
 
+.toggleMatchStrategy {
+	font-size:12px;
+}
+
 .resultMatchStrategy {
 	position:relative;
+	background-color:#EEEEEE;
+	display:none;
 }
 
 .leftMatchStrategy {
@@ -326,8 +332,14 @@ display: inline-block;
     left: 10px;
 }
 
+.toggleSortOrder {
+	font-size:12px;
+}
+
 .resultSortOrder {
 	position:relative;
+	background-color:#EEEEEE;
+	display:none;
 }
 
 .rightSortOrder {

--- a/src/main/webapp/jsp/default.jsp
+++ b/src/main/webapp/jsp/default.jsp
@@ -6,7 +6,7 @@
   <%@include file="includes/siteParams.jsp"%>
   <table width="100%">
     <tr>
-      <td width="160" valign="top">
+      <td width="200" valign="top">
         <div class="navigation">
           <%@include file="includes/navigation.jsp"%>
         </div>

--- a/src/main/webapp/jsp/includes/form.jsp
+++ b/src/main/webapp/jsp/includes/form.jsp
@@ -16,7 +16,9 @@
   <input type="text" name="excludedNavigations" id="excludedNavigations" placeholder="Excluded Navigations" style="width:125px;margin-top:10px"><br />
   <input type="text" name="fields" id="fields" placeholder="Field List, comma separated" style="width:750px;margin-top:10px"><br />
   <input type="text" name="bringToTop" id="bringToTop" placeholder="Bring To Top, comma separated list of Product IDs" style="width:750px;margin-top:10px"><br />
+  <br />
   <input type="hidden" name="biasingProfile" id="biasingProfile">
+  <input type="hidden" name="matchStrategy" id="matchStrategy">
 </form>
 </div>
 <form id="form" accept-charset="UTF-8" action="<c:url value="${b:toUrlAdd('default', results.query, results.selectedNavigation, 'selected', null) }"/>">

--- a/src/main/webapp/jsp/includes/form.jsp
+++ b/src/main/webapp/jsp/includes/form.jsp
@@ -19,6 +19,7 @@
   <br />
   <input type="hidden" name="biasingProfile" id="biasingProfile">
   <input type="hidden" name="matchStrategy" id="matchStrategy">
+  <input type="hidden" name="recordColumnSortOrder" id="recordColumnSortOrder">
 </form>
 </div>
 <form id="form" accept-charset="UTF-8" action="<c:url value="${b:toUrlAdd('default', results.query, results.selectedNavigation, 'selected', null) }"/>">

--- a/src/main/webapp/jsp/includes/form.jsp
+++ b/src/main/webapp/jsp/includes/form.jsp
@@ -13,7 +13,9 @@
   <input type="text" name="sortField" id="sortField" placeholder="Sort Field" style="width:100px;margin-top:10px">
   <input type="text" name="sortOrder" id="sortOrder" placeholder="Sort Order (A or D)" style="width:150px;margin-top:10px"><br />
   <input type="text" name="includedNavigations" id="includedNavigations" placeholder="Included Navigations" style="width:125px;margin-top:10px">
-  <input type="text" name="excludedNavigations" id="excludedNavigations" placeholder="Excluded Navigations" style="width:125px;margin-top:10px"><br />
+  <input type="text" name="excludedNavigations" id="excludedNavigations" placeholder="Excluded Navigations" style="width:125px;margin-top:10px"> | 
+  <input type="text" name="pageSize" id="pageSize" placeholder="Number of Records per Page" style="width:250px;margin-top:10px">
+  <br />
   <input type="text" name="fields" id="fields" placeholder="Field List, comma separated" style="width:750px;margin-top:10px"><br />
   <input type="text" name="bringToTop" id="bringToTop" placeholder="Bring To Top, comma separated list of Product IDs" style="width:750px;margin-top:10px"><br />
   <input type="text" name="imagePath" id="imagePath" placeholder="Dot notation path to image attribute" style="width:250px;margin-top:10px">
@@ -84,3 +86,4 @@
         saveForm();
     });
 </script>
+

--- a/src/main/webapp/jsp/includes/form.jsp
+++ b/src/main/webapp/jsp/includes/form.jsp
@@ -16,6 +16,9 @@
   <input type="text" name="excludedNavigations" id="excludedNavigations" placeholder="Excluded Navigations" style="width:125px;margin-top:10px"><br />
   <input type="text" name="fields" id="fields" placeholder="Field List, comma separated" style="width:750px;margin-top:10px"><br />
   <input type="text" name="bringToTop" id="bringToTop" placeholder="Bring To Top, comma separated list of Product IDs" style="width:750px;margin-top:10px"><br />
+  <input type="text" name="imagePath" id="imagePath" placeholder="Dot notation path to image attribute" style="width:250px;margin-top:10px">
+  <input type="text" name="imagePathPrefix" id="imagePathPrefix" placeholder="Prefix for each image" style="width:250px;margin-top:10px">
+  <input type="text" name="imagePathSuffix" id="imagePathSuffix" placeholder="Suffix for each image" style="width:250px;margin-top:10px"><br />
   <br />
   <input type="hidden" name="biasingProfile" id="biasingProfile">
   <input type="hidden" name="matchStrategy" id="matchStrategy">

--- a/src/main/webapp/jsp/includes/navLink.jsp
+++ b/src/main/webapp/jsp/includes/navLink.jsp
@@ -9,12 +9,12 @@
 					<c:if test="${!gc:isRefinementSelected(results, nav.name, value.value)}">
 
 						<div>
-							<a style="color:white" href="<c:url value="${b:toUrlAdd('default', results.query, results.selectedNavigation, nav.name, value)}"/>">&#x2610; ${value.value} (${value['count'] })</a>
+							<a href="<c:url value="${b:toUrlAdd('default', results.query, results.selectedNavigation, nav.name, value)}"/>">&#x2610; ${value.value} (${value['count'] })</a>
 						</div>
 					</c:if>
 					<c:if test="${gc:isRefinementSelected(results, nav.name, value.value)}">
 						<div>
-							<a class="selected"  style="color:white" href="<c:url value="${b:toUrlRemove('default', results.query, results.selectedNavigation, nav.name, value)}"/>">&#x2611; ${value.value} (${value['count'] })</a>
+							<a class="selected" href="<c:url value="${b:toUrlRemove('default', results.query, results.selectedNavigation, nav.name, value)}"/>">&#x2611; ${value.value} (${value['count'] })</a>
 						</div>
 					</c:if>
 				</div>
@@ -28,7 +28,7 @@
 		<div class="nav-${nav.name}">
 			<c:forEach items="${nav.refinements}" var="value">
 				<div>
-					<a style="color:white" href="<c:url value="${b:toUrlAdd('default', results.query, results.selectedNavigation, nav.name, value)}"/>">${value.value} (${value['count'] })</a>
+					<a href="<c:url value="${b:toUrlAdd('default', results.query, results.selectedNavigation, nav.name, value)}"/>">${value.value} (${value['count'] })</a>
 				</div>
 			</c:forEach>
 		</div>
@@ -36,7 +36,7 @@
 </c:if>
 <c:if test="${nav.isMoreRefinements()}">
 	<div id="more-${nav.name}">
-		<a style="color:white" href="#" onclick='getMoreNav("${nav.name}")'>More [+]</a>
+		<a href="#" onclick='getMoreNav("${nav.name}")'>More [+]</a>
 	</div>
 </c:if>
 <script>

--- a/src/main/webapp/jsp/includes/navLinkRange.jsp
+++ b/src/main/webapp/jsp/includes/navLinkRange.jsp
@@ -4,7 +4,7 @@
 <b>${nav.displayName}</b>
 <c:forEach items="${nav.refinements}" var="value">
 <div>
-  <a style="color:white" href="<c:url value="${b:toUrlAdd('default', results.query, results.selectedNavigation, nav.name, value)}"/>">
+  <a href="<c:url value="${b:toUrlAdd('default', results.query, results.selectedNavigation, nav.name, value)}"/>">
 		  <fmt:formatNumber pattern="0.00">${value['low']}</fmt:formatNumber> 
 	      ${empty value['high'] ? '+' : '-'} 
 	      <fmt:formatNumber pattern="0.00">${value['high']}</fmt:formatNumber>

--- a/src/main/webapp/jsp/includes/record.jsp
+++ b/src/main/webapp/jsp/includes/record.jsp
@@ -2,22 +2,55 @@
     <li class="record highlightCorresponding h${record.id}" data-id="row${b.index}.h${record.id}">
         <h2>Record ${i.index + results.pageInfo.recordStart}</h2>
         <div class="details">
-            <c:forEach items="${record.allMeta}" var="entry">
-                <c:if test="${!(fn:startsWith(entry.value, '[{') || fn:startsWith(entry.value, '{'))}">
-                  <div class="keyValue"><span class="key">${entry.key}</span>:
-                      <span class="value">${entry.value }</span></div>
-                </c:if>
-                <c:if test="${fn:startsWith(entry.value, '[{') || fn:startsWith(entry.value, '[{')}">
-                    <div class="keyValue"><span class="key">${entry.key}</span>:
-                        <span class="value reformatJson">${entry.value }</span></div>
-                </c:if>
-            </c:forEach>
-            <c:forEach items="${record.allMeta}" var="entry">
-                <c:if test="${fn:contains(entry.key, 'image') or fn:endsWith(fn:toLowerCase(entry.value), '.jpg') or fn:endsWith(fn:toLowerCase(entry.value), '.jpeg') or fn:endsWith(fn:toLowerCase(entry.value), '.png') or fn:endsWith(fn:toLowerCase(entry.value), '.gif')}">
-                    ${entry.key}:
-                    <img style="display: inline-block; max-width: 200px; max-height: 200px; margin: 5px;" src="${entry.value}"/>
-                </c:if>
-            </c:forEach>
+        	<ul>
+		<c:forEach items="${record.allMeta}" var="entry"> 
+			<c:if test="${!(fn:startsWith(entry.value, '[{') || fn:startsWith(entry.value, '{'))}">
+				<li><b>${entry.key}:</b> ${entry.value}</li>	
+			</c:if>
+			<c:if test="${fn:startsWith(entry.value, '[{') || fn:startsWith(entry.value, '[{')}">
+				<li><b>${entry.key}:</b> ${entry.value }</li>
+			</c:if>
+			<c:if test="${fn:startsWith(entry.value, '{')}">
+				<ul>
+				<c:forEach items="${entry.value}" var="entry2">
+					<c:if test="${!(fn:startsWith(entry2.value, '[{') || fn:startsWith(entry2.value, '{'))}">
+						<li><b>${entry.key}.${entry2.key}:</b> ${entry2.value}</li>
+					</c:if>
+					<c:if test="${fn:startsWith(entry2.value, '{')}">
+						<ul>
+						<c:forEach items="${entry2.value}" var="entry3">
+							<c:if test="${!(fn:startsWith(entry3.value, '[{') || fn:startsWith(entry3.value, '{'))}">
+								<li><b>${entry.key}.${entry2.key}.${entry3.key}:</b> ${entry3.value}</li>
+							</c:if>						
+							<c:if test="${fn:startsWith(entry3.value, '{') || fn:startsWith(entry3.value, '[{') }">
+								<ul>
+								<c:forEach items="${entry3.value}" var="entry4">
+									<c:if test="${fn:startsWith(entry4, '{') || fn:startsWith(entry4, '[{') }">
+										<c:forEach items="${entry4}" var="entry5">
+											<li><b>${entry.key}.${entry2.key}.${entry3.key}.${entry5.key}:</b> ${entry5.value}</li>
+										</c:forEach>										
+									</c:if>
+									<c:if test="${!(fn:startsWith(entry4, '[{') || fn:startsWith(entry4, '{'))}">
+										<li><b>${entry.key}.${entry2.key}.${entry3.key}.${entry4.key}:</b> ${entry4}</li>				
+									</c:if>
+								</c:forEach>
+								</ul>
+							</c:if>
+						</c:forEach>
+						</ul>
+				
+					</c:if>
+				</c:forEach>
+				</ul>
+			</c:if>
+		</c:forEach>
+		<c:forEach items="${record.allMeta}" var="entry">
+			<c:if test="${fn:contains(entry.key, 'image') or fn:endsWith(fn:toLowerCase(entry.value), '.jpg') or fn:endsWith(fn:toLowerCase(entry.value), '.jpeg') or fn:endsWith(fn:toLowerCase(entry.value), '.png') or fn:endsWith(fn:toLowerCase(entry.value), '.gif')}">
+				${entry.key}:
+				<img style="display: inline-block; max-width: 200px; max-height: 200px; margin: 5px;" src="${entry.value}"/>
+			</c:if>
+		</c:forEach>
+		</ul>
         </div>
     </li>
 </c:forEach>

--- a/src/main/webapp/jsp/includes/record.jsp
+++ b/src/main/webapp/jsp/includes/record.jsp
@@ -45,7 +45,7 @@
 			</c:if>
 		</c:forEach>
 		<c:forEach items="${record.allMeta}" var="entry">
-			<c:if test="${fn:contains(entry.key, 'image') or fn:endsWith(fn:toLowerCase(entry.value), '.jpg') or fn:endsWith(fn:toLowerCase(entry.value), '.jpeg') or fn:endsWith(fn:toLowerCase(entry.value), '.png') or fn:endsWith(fn:toLowerCase(entry.value), '.gif')}">
+			<c:if test="${(fn:contains(entry.key, 'image') or fn:endsWith(fn:toLowerCase(entry.value), '.jpg') or fn:endsWith(fn:toLowerCase(entry.value), '.jpeg') or fn:endsWith(fn:toLowerCase(entry.value), '.png') or fn:endsWith(fn:toLowerCase(entry.value), '.gif')) and (fn:startsWith(fn:toLowerCase(entry.value),'http') or fn:startsWith(fn:toLowerCase(entry.value),'https'))}">
 				${entry.key}:
 				<img style="display: inline-block; max-width: 200px; max-height: 200px; margin: 5px;" src="${entry.value}"/>
 			</c:if>

--- a/src/main/webapp/jsp/includes/record.jsp
+++ b/src/main/webapp/jsp/includes/record.jsp
@@ -2,22 +2,56 @@
     <li class="record highlightCorresponding h${record.id}" data-id="row${b.index}.h${record.id}">
         <h2>Record ${i.index + results.pageInfo.recordStart}</h2>
         <div class="details">
-            <c:forEach items="${record.allMeta}" var="entry">
-                <c:if test="${!(fn:startsWith(entry.value, '[{') || fn:startsWith(entry.value, '{'))}">
-                  <div class="keyValue"><span class="key">${entry.key}</span>:
-                      <span class="value">${entry.value }</span></div>
-                </c:if>
-                <c:if test="${fn:startsWith(entry.value, '[{') || fn:startsWith(entry.value, '[{')}">
-                    <div class="keyValue"><span class="key">${entry.key}</span>:
-                        <span class="value reformatJson">${entry.value }</span></div>
-                </c:if>
-            </c:forEach>
-            <c:forEach items="${record.allMeta}" var="entry">
-                <c:if test="${fn:contains(entry.key, 'image') or fn:endsWith(fn:toLowerCase(entry.value), '.jpg') or fn:endsWith(fn:toLowerCase(entry.value), '.jpeg') or fn:endsWith(fn:toLowerCase(entry.value), '.png') or fn:endsWith(fn:toLowerCase(entry.value), '.gif')}">
-                    ${entry.key}:
-                    <img style="display: inline-block; max-width: 200px; max-height: 200px; margin: 5px;" src="${entry.value}"/>
-                </c:if>
-            </c:forEach>
+        	<ul>
+		<c:forEach items="${record.allMeta}" var="entry"> 
+			<c:if test="${!(fn:startsWith(entry.value, '[{') || fn:startsWith(entry.value, '{'))}">
+				<li><b>${entry.key}:</b> ${entry.value}</li>	
+			</c:if>
+			<c:if test="${fn:startsWith(entry.value, '[{') || fn:startsWith(entry.value, '[{')}">
+				<li><b>${entry.key}:</b> ${entry.value }</li>
+			</c:if>
+			<c:if test="${fn:startsWith(entry.value, '{')}">
+				<ul>
+				<c:forEach items="${entry.value}" var="entry2">
+					<c:if test="${!(fn:startsWith(entry2.value, '[{') || fn:startsWith(entry2.value, '{'))}">
+						<li><b>${entry.key}.${entry2.key}:</b> ${entry2.value}</li>
+					</c:if>
+					<c:if test="${fn:startsWith(entry2.value, '{')}">
+						<ul>
+						<c:forEach items="${entry2.value}" var="entry3">
+							<c:if test="${!(fn:startsWith(entry3.value, '[{') || fn:startsWith(entry3.value, '{'))}">
+								<li><b>${entry.key}.${entry2.key}.${entry3.key}:</b> ${entry3.value}</li>
+							</c:if>						
+							<c:if test="${fn:startsWith(entry3.value, '{') || fn:startsWith(entry3.value, '[{') }">
+								<ul>
+								<c:forEach items="${entry3.value}" var="entry4">
+									<c:if test="${fn:startsWith(entry4, '{') || fn:startsWith(entry4, '[{') }">
+										<c:forEach items="${entry4}" var="entry5">
+											<li><b>${entry.key}.${entry2.key}.${entry3.key}.${entry5.key}:</b> ${entry5.value}</li>
+										</c:forEach>										
+									</c:if>
+									<c:if test="${!(fn:startsWith(entry4, '[{') || fn:startsWith(entry4, '{'))}">
+										<li><b>${entry.key}.${entry2.key}.${entry3.key}.${entry4.key}:</b> ${entry4}</li>				
+									</c:if>
+								</c:forEach>
+								</ul>
+							</c:if>
+						</c:forEach>
+						</ul>
+				
+					</c:if>
+				</c:forEach>
+				</ul>
+			</c:if>
+		</c:forEach>
+		<c:forEach items="${record.allMeta}" var="entry">
+			<c:if test="${fn:contains(entry.key, 'image') or fn:endsWith(fn:toLowerCase(entry.value), '.jpg') or fn:endsWith(fn:toLowerCase(entry.value), '.jpeg') or fn:endsWith(fn:toLowerCase(entry.value), '.png') or fn:endsWith(fn:toLowerCase(entry.value), '.gif')}">
+				${entry.key}:
+				<img style="display: inline-block; max-width: 200px; max-height: 200px; margin: 5px;" src="${entry.value}"/>
+			</c:if>
+		</c:forEach>
+		</ul>
         </div>
     </li>
 </c:forEach>
+

--- a/src/main/webapp/jsp/includes/results.jsp
+++ b/src/main/webapp/jsp/includes/results.jsp
@@ -30,6 +30,7 @@
 <BR>
 <a class="toggleSortOrder" href="javascript:;" onclick="$.cookie('resultSortOrder${index}', !$('#resultSortOrder${index}').is(':visible'));$('#resultSortOrder${index}').toggle('slide')">show sort order >></a>
 <div id="resultSortOrder${b.index}" class="resultSortOrder">
+	<a href="javascript:;" class="leftSortOrder" onclick="titleSortOrder(${b.index})">Title Sort Order</a>
 	<a href="javascript:;" class="rightSortOrder" onclick="resetSortOrder(${b.index})">Default Sort Order</a><br>
 	<textarea id="sortOrder${b.index}" value="${results.sortOrder}" placeholder="[{ 'field': '_relevance' }]" rows=5 style="width:100%">${results.sortOrder}</textarea><br>
 </div>
@@ -151,6 +152,20 @@
             matchStrategies = matchStrategies.substring(0, matchStrategies.length-1);
             $('#matchStrategy').val(matchStrategies);
             $('#matchStrategy').trigger('change');
+            saveForm();
+            $('#form').submit();
+    }
+
+    function titleSortOrder(pIndex){
+	    document.getElementById("sortOrder"+pIndex).value="[{'field':'title','order':'Ascending'},{ 'field': '_relevance' }]";
+	    saveForm();
+	    var sortOrders = '';
+            $('.recordColumn .resultSortOrder textarea').each(function(){
+                sortOrders += $(this).val() +  "|";
+            });
+            sortOrders = sortOrders.substring(0, sortOrders.length-1);
+            $('#recordColumnSortOrder').val(sortOrders);
+            $('#recordColumnSortOrder').trigger('change');
             saveForm();
             $('#form').submit();
     }

--- a/src/main/webapp/jsp/includes/results.jsp
+++ b/src/main/webapp/jsp/includes/results.jsp
@@ -26,6 +26,11 @@
 	<a href="javascript:;" class="rightMatchStrategy" onclick="resetMatchStrategy(${b.index})">Default Match Strategy</a><br>
 <textarea id="matchStrategy${b.index}" value="${results.matchStrategy}" placeholder="[{ 'terms': 2, 'mustMatch': 2 }, { 'terms': 3, 'mustMatch': 2 }, { 'terms': 4, 'mustMatch': 3 }, { 'terms': 5, 'mustMatch': 3 }, { 'terms': 6, 'mustMatch': 4 }, { 'terms': 7, 'mustMatch': 4 }, { 'terms': 8, 'mustMatch': 5 }, { 'termsGreaterThan': 8, 'mustMatch': 60, 'percentage': true }]" rows=5 style="width:100%">${results.matchStrategy}</textarea><br>
 </div>
+<BR>
+<div class="resultSortOrder">
+	<a href="javascript:;" class="rightSortOrder" onclick="resetSortOrder(${b.index})">Default Sort Order</a><br>
+	<textarea id="sortOrder${b.index}" value="${results.sortOrder}" placeholder="[{ 'field': '_relevance' }]" rows=5 style="width:100%">${results.sortOrder}</textarea><br>
+</div>
 
 
 <ol id="replacementRow${b.index}" style="display: none">
@@ -66,9 +71,9 @@
         }
     });
 
-    $('.recordColumn textarea').keydown(function(e){
+    $('.resultMatchStrategy textarea').keydown(function(e){
 	    var matchStrategies = '';
-            $('.recordColumn textarea').each(function(){
+            $('.resultMatchStrategy textarea').each(function(){
                 matchStrategies += $(this).val() +  "|"
             });
             matchStrategies = matchStrategies.substring(0, matchStrategies.length-1);
@@ -82,11 +87,32 @@
             $('#form').submit();
 	} 
     });
+
+	$('.resultSortOrder textarea').keydown(function(e){
+	    var sortOrders = '';
+            $('.resultSortOrder textarea').each(function(){
+                sortOrders += $(this).val() +  "|"
+            });
+            sortOrders = sortOrders.substring(0, sortOrders.length-1);
+            $('#recordColumnSortOrder').val(sortOrders);
+            $('#recordColumnSortOrder').trigger('change');
+        var code = (e.keyCode ? e.keyCode : e.which);
+        if (code == 13) {
+            e.preventDefault();
+            e.stopPropagation();
+            saveForm();
+            $('#form').submit();
+	} 
+    });
     
     function removeColumn(pIndex){
         $('#biasing' + pIndex).parent().hide('slide');
         $('#biasing' + pIndex).remove();
+        $('#matchStrategy' + pIndex).remove();
+        $('#sortOrder' + pIndex).remove();
         $('.recordColumn input').trigger('keyup');
+        $('.resultMatchStrategy textarea').trigger('keydown');
+        $('.resultSortOrder textarea').trigger('keydown');
         saveForm();
         $('#form').submit();
     }
@@ -103,7 +129,7 @@
 	    document.getElementById("matchStrategy"+pIndex).value="[{ 'terms': 2, 'mustMatch': 2 }, { 'terms': 3, 'mustMatch': 2 }, { 'terms': 4, 'mustMatch': 3 }, { 'terms': 5, 'mustMatch': 3 }, { 'terms': 6, 'mustMatch': 4 }, { 'terms': 7, 'mustMatch': 4 }, { 'terms': 8, 'mustMatch': 5 }, { 'termsGreaterThan': 8, 'mustMatch': 60, 'percentage': true }]";
 	    saveForm();
 	    var matchStrategies = '';
-            $('.recordColumn textarea').each(function(){
+            $('.resultMatchStrategy textarea').each(function(){
                 matchStrategies += $(this).val() +  "|";
             });
             matchStrategies = matchStrategies.substring(0, matchStrategies.length-1);
@@ -117,7 +143,7 @@
 	    document.getElementById("matchStrategy"+pIndex).value="[{ 'termsGreaterThan': 1, 'mustMatch': 100, 'percentage': true }]";
 	    saveForm();
 	    var matchStrategies = '';
-            $('.recordColumn textarea').each(function(){
+            $('.resultMatchStrategy textarea').each(function(){
                 matchStrategies += $(this).val() +  "|";
             });
             matchStrategies = matchStrategies.substring(0, matchStrategies.length-1);
@@ -126,4 +152,19 @@
             saveForm();
             $('#form').submit();
     }
+
+    function resetSortOrder(pIndex){
+	    document.getElementById("sortOrder"+pIndex).value="[{ 'field': '_relevance' }]";
+	    saveForm();
+	    var sortOrders = '';
+            $('.recordColumn .resultSortOrder textarea').each(function(){
+                sortOrders += $(this).val() +  "|";
+            });
+            sortOrders = sortOrders.substring(0, sortOrders.length-1);
+            $('#recordColumnSortOrder').val(sortOrders);
+            $('#recordColumnSortOrder').trigger('change');
+            saveForm();
+            $('#form').submit();
+    }
 </script>
+

--- a/src/main/webapp/jsp/includes/results.jsp
+++ b/src/main/webapp/jsp/includes/results.jsp
@@ -7,15 +7,25 @@
 <c:forEach begin="0" end="${biasingProfileCount -1}" varStatus="b">
 <c:set var="name" value="results${b.index}"/>
 <c:set var="results" value="${model[name]}"/>
-<td class="recordColumn" style="padding-right:2px;" valign="top" width="width:${width}%">
+<td class="recordColumn" style="padding-right:10px;" valign="top" width="width:${width}%">
 
 <c:set var="index" value="${b.index}"/>
 <%@include file="debug.jsp"%>
+<div class="resultBiasAndCount">
 <input type="text" id="biasing${b.index}" value="${results.biasingProfile}" placeholder="Biasing Profile" style="width:120px;">
 <c:if test="${b.index > 0}">
 <a href="javascript:;" onclick="removeColumn(${b.index});">-</a>
 </c:if>
 <a href="javascript:;" onclick="addColumn(${b.index})">+</a>
+<div class="totalRecordCountTitle">Total Record Count:</div><div class="totalRecordCount"> ${results.totalRecordCount}</div>
+</div>
+
+<BR>
+<div class="resultMatchStrategy">
+	<a href="javascript:;" class="leftMatchStrategy" onclick="exactMatchStrategy(${b.index})">Exact Match Strategy</a>
+	<a href="javascript:;" class="rightMatchStrategy" onclick="resetMatchStrategy(${b.index})">Default Match Strategy</a><br>
+<textarea id="matchStrategy${b.index}" value="${results.matchStrategy}" placeholder="[{ 'terms': 2, 'mustMatch': 2 }, { 'terms': 3, 'mustMatch': 2 }, { 'terms': 4, 'mustMatch': 3 }, { 'terms': 5, 'mustMatch': 3 }, { 'terms': 6, 'mustMatch': 4 }, { 'terms': 7, 'mustMatch': 4 }, { 'terms': 8, 'mustMatch': 5 }, { 'termsGreaterThan': 8, 'mustMatch': 60, 'percentage': true }]" rows=5 style="width:100%">${results.matchStrategy}</textarea><br>
+</div>
 
 
 <ol id="replacementRow${b.index}" style="display: none">
@@ -56,6 +66,23 @@
         }
     });
 
+    $('.recordColumn textarea').keydown(function(e){
+	    var matchStrategies = '';
+            $('.recordColumn textarea').each(function(){
+                matchStrategies += $(this).val() +  "|"
+            });
+            matchStrategies = matchStrategies.substring(0, matchStrategies.length-1);
+            $('#matchStrategy').val(matchStrategies);
+            $('#matchStrategy').trigger('change');
+        var code = (e.keyCode ? e.keyCode : e.which);
+        if (code == 13) {
+            e.preventDefault();
+            e.stopPropagation();
+            saveForm();
+            $('#form').submit();
+	} 
+    });
+    
     function removeColumn(pIndex){
         $('#biasing' + pIndex).parent().hide('slide');
         $('#biasing' + pIndex).remove();
@@ -70,5 +97,33 @@
         $('#biasingProfile').trigger('change');
         saveForm();
         $('#form').submit();
+    }
+
+    function resetMatchStrategy(pIndex){
+	    document.getElementById("matchStrategy"+pIndex).value="[{ 'terms': 2, 'mustMatch': 2 }, { 'terms': 3, 'mustMatch': 2 }, { 'terms': 4, 'mustMatch': 3 }, { 'terms': 5, 'mustMatch': 3 }, { 'terms': 6, 'mustMatch': 4 }, { 'terms': 7, 'mustMatch': 4 }, { 'terms': 8, 'mustMatch': 5 }, { 'termsGreaterThan': 8, 'mustMatch': 60, 'percentage': true }]";
+	    saveForm();
+	    var matchStrategies = '';
+            $('.recordColumn textarea').each(function(){
+                matchStrategies += $(this).val() +  "|";
+            });
+            matchStrategies = matchStrategies.substring(0, matchStrategies.length-1);
+            $('#matchStrategy').val(matchStrategies);
+            $('#matchStrategy').trigger('change');
+            saveForm();
+            $('#form').submit();
+    }
+
+    function exactMatchStrategy(pIndex){
+	    document.getElementById("matchStrategy"+pIndex).value="[{ 'termsGreaterThan': 1, 'mustMatch': 100, 'percentage': true }]";
+	    saveForm();
+	    var matchStrategies = '';
+            $('.recordColumn textarea').each(function(){
+                matchStrategies += $(this).val() +  "|";
+            });
+            matchStrategies = matchStrategies.substring(0, matchStrategies.length-1);
+            $('#matchStrategy').val(matchStrategies);
+            $('#matchStrategy').trigger('change');
+            saveForm();
+            $('#form').submit();
     }
 </script>

--- a/src/main/webapp/jsp/includes/results.jsp
+++ b/src/main/webapp/jsp/includes/results.jsp
@@ -21,18 +21,17 @@
 </div>
 
 <BR>
-<a class="toggleMatchStrategy" href="javascript:;" onclick="$.cookie('resultMatchStrategy${index}', !$('#resultMatchStrategy${index}').is(':visible'));$('#resultMatchStrategy${index}').toggle('slide')">show match strategy >></a>
+<a class="toggleMatchStrategy" href="javascript:;" onclick="$.cookie('resultMatchStrategy${b.index}', !$('#resultMatchStrategy${b.index}').is(':visible'));$('#resultMatchStrategy${b.index}').toggle('slide');$('#showMatchStrategyText${b.index}').toggle('slide');$('#hideMatchStrategyText${b.index}').toggle('slide');"><div id="showMatchStrategyText${b.index}">show match strategy >></div><div id="hideMatchStrategyText${b.index}" style="display:none">hide match strategy >></div></a>
 <div id="resultMatchStrategy${b.index}" class="resultMatchStrategy">
 	<a href="javascript:;" class="leftMatchStrategy" onclick="exactMatchStrategy(${b.index})">Exact Match Strategy</a>
 	<a href="javascript:;" class="rightMatchStrategy" onclick="resetMatchStrategy(${b.index})">Default Match Strategy</a><br>
-<textarea id="matchStrategy${b.index}" value="${results.matchStrategy}" placeholder="[{ 'terms': 2, 'mustMatch': 2 }, { 'terms': 3, 'mustMatch': 2 }, { 'terms': 4, 'mustMatch': 3 }, { 'terms': 5, 'mustMatch': 3 }, { 'terms': 6, 'mustMatch': 4 }, { 'terms': 7, 'mustMatch': 4 }, { 'terms': 8, 'mustMatch': 5 }, { 'termsGreaterThan': 8, 'mustMatch': 60, 'percentage': true }]" rows=5 style="width:100%">${results.matchStrategy}</textarea><br>
+<textarea id="matchStrategy${b.index}" value="${results.matchStrategy}" placeholder="[{ 'terms': 2, 'mustMatch': 2 }, { 'terms': 3, 'mustMatch': 2 }, { 'terms': 4, 'mustMatch': 3 }, { 'terms': 5, 'mustMatch': 3 }, { 'terms': 6, 'mustMatch': 4 }, { 'terms': 7, 'mustMatch': 4 }, { 'terms': 8, 'mustMatch': 5 }, { 'termsGreaterThan': 8, 'mustMatch': 60, 'percentage': true }]" rows=5>${results.matchStrategy}</textarea>
 </div>
-<BR>
-<a class="toggleSortOrder" href="javascript:;" onclick="$.cookie('resultSortOrder${index}', !$('#resultSortOrder${index}').is(':visible'));$('#resultSortOrder${index}').toggle('slide')">show sort order >></a>
+<a class="toggleSortOrder" href="javascript:;" onclick="$.cookie('resultSortOrder${b.index}', !$('#resultSortOrder${b.index}').is(':visible'));$('#resultSortOrder${b.index}').toggle('slide');$('#showSortText${b.index}').toggle('slide');$('#hideSortText${b.index}').toggle('slide');"><div id="showSortText${b.index}">show sort order >></div><div id="hideSortText${b.index}" style="display:none">hide sort order >></div></a>
 <div id="resultSortOrder${b.index}" class="resultSortOrder">
 	<a href="javascript:;" class="leftSortOrder" onclick="titleSortOrder(${b.index})">Title Sort Order</a>
 	<a href="javascript:;" class="rightSortOrder" onclick="resetSortOrder(${b.index})">Default Sort Order</a><br>
-	<textarea id="sortOrder${b.index}" value="${results.sortOrder}" placeholder="[{ 'field': '_relevance' }]" rows=5 style="width:100%">${results.sortOrder}</textarea><br>
+	<textarea id="sortOrder${b.index}" value="${results.sortOrder}" placeholder="[{ 'field': '_relevance' }]" rows=5>${results.sortOrder}</textarea>
 </div>
 
 

--- a/src/main/webapp/jsp/includes/results.jsp
+++ b/src/main/webapp/jsp/includes/results.jsp
@@ -21,13 +21,15 @@
 </div>
 
 <BR>
-<div class="resultMatchStrategy">
+<a class="toggleMatchStrategy" href="javascript:;" onclick="$.cookie('resultMatchStrategy${index}', !$('#resultMatchStrategy${index}').is(':visible'));$('#resultMatchStrategy${index}').toggle('slide')">show match strategy >></a>
+<div id="resultMatchStrategy${b.index}" class="resultMatchStrategy">
 	<a href="javascript:;" class="leftMatchStrategy" onclick="exactMatchStrategy(${b.index})">Exact Match Strategy</a>
 	<a href="javascript:;" class="rightMatchStrategy" onclick="resetMatchStrategy(${b.index})">Default Match Strategy</a><br>
 <textarea id="matchStrategy${b.index}" value="${results.matchStrategy}" placeholder="[{ 'terms': 2, 'mustMatch': 2 }, { 'terms': 3, 'mustMatch': 2 }, { 'terms': 4, 'mustMatch': 3 }, { 'terms': 5, 'mustMatch': 3 }, { 'terms': 6, 'mustMatch': 4 }, { 'terms': 7, 'mustMatch': 4 }, { 'terms': 8, 'mustMatch': 5 }, { 'termsGreaterThan': 8, 'mustMatch': 60, 'percentage': true }]" rows=5 style="width:100%">${results.matchStrategy}</textarea><br>
 </div>
 <BR>
-<div class="resultSortOrder">
+<a class="toggleSortOrder" href="javascript:;" onclick="$.cookie('resultSortOrder${index}', !$('#resultSortOrder${index}').is(':visible'));$('#resultSortOrder${index}').toggle('slide')">show sort order >></a>
+<div id="resultSortOrder${b.index}" class="resultSortOrder">
 	<a href="javascript:;" class="rightSortOrder" onclick="resetSortOrder(${b.index})">Default Sort Order</a><br>
 	<textarea id="sortOrder${b.index}" value="${results.sortOrder}" placeholder="[{ 'field': '_relevance' }]" rows=5 style="width:100%">${results.sortOrder}</textarea><br>
 </div>

--- a/src/main/webapp/jsp/includes/tags.jsp
+++ b/src/main/webapp/jsp/includes/tags.jsp
@@ -1,4 +1,5 @@
 <%@ page pageEncoding="UTF-8"%>
+<%@page contentType="text/html; charset=UTF-8" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions"%>

--- a/src/main/webapp/jsp/index.jsp
+++ b/src/main/webapp/jsp/index.jsp
@@ -36,7 +36,8 @@
         <jsp:include  page="default.jsp"/>
       </c:when>
       <c:otherwise>
-        <h2>Landing page not defined: "${results.template.name}"</h2>
+      <h3><strong>Triggered Rule:</strong> "${results.template.ruleName}"<BR>
+	      <strong>Triggered Template:</strong> "${results.template.name}"</h3>
         <jsp:include  page="default.jsp"/>
       </c:otherwise>
     </c:choose>

--- a/src/main/webapp/jsp/index.jsp
+++ b/src/main/webapp/jsp/index.jsp
@@ -37,7 +37,8 @@
       </c:when>
       <c:otherwise>
       <h3><strong>Triggered Rule:</strong> "${results.template.ruleName}"<BR>
-	      <strong>Triggered Template:</strong> "${results.template.name}"</h3>
+	      <strong>Triggered Template:</strong> "${results.template.name}"<BR>
+      <strong>Rewrites:</strong> ${results.rewrites}</h3>
         <jsp:include  page="default.jsp"/>
       </c:otherwise>
     </c:choose>


### PR DESCRIPTION
This version of the quickstart incorporates changes made for Zoro Tools:
1. Enable users to specify a match strategy per results column
2. Display any triggered rule, template or query rewrites
3. Extensive style changes implemented by Olya Sanakoev
