### PR TITLE
Version Upgrade [api-java-flux]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <groupbyinc.api.version>[2.2.57,3.0.0)</groupbyinc.api.version>
+        <groupbyinc.api.version>2.2.81</groupbyinc.api.version>
         <groupbyinc.docker.base.version>1.8</groupbyinc.docker.base.version>
         <groupbyinc.docker.repo>docker.groupbyinc.com</groupbyinc.docker.repo>
         <groupbyinc.docker.image.name>docker.groupbyinc.com/${project.artifactId}</groupbyinc.docker.image.name>


### PR DESCRIPTION
### Library Upgrade
- org.springframework.boot:spring-boot-starter-web:1.3.3.RELEASE -->  1.3.5.RELEASE
- ✓ com.groupbyinc:api-java-flux:[2.2.57,3.0.0) -->  2.2.81
- org.springframework.boot:spring-boot-starter-actuator:1.3.3.RELEASE -->  1.3.5.RELEASE
- org.springframework.boot:spring-boot-starter-test:1.3.3.RELEASE -->  1.3.5.RELEASE
- org.springframework.boot:spring-boot-starter-tomcat:1.3.3.RELEASE -->  1.3.5.RELEASE

---

Upgrade brought to you by GroupBy <a href="https://github.com/groupby/dependency-checker">dependency-checker</a>
